### PR TITLE
Modify check_and_clean_df to allow tibbles to be used in meta-analysis functions

### DIFF
--- a/R/metamean.R
+++ b/R/metamean.R
@@ -137,6 +137,10 @@ metamean <- function(data, mean_method = 'mln', se_method,
 check_and_clean_df <- function(df, method){
   if (!is.data.frame(df)){
     stop("'data' must be of class data.frame")
+  } else {
+    if ("tbl_df" %in% class(df)) {
+      df <- as.data.frame(df)
+    }
   }
   if (length(method) == 1 && method == 'cd'){
     all_possible_colnames <- c('q1.g1', 'med.g1', 'q3.g1', 'n.g1', 'mean.g1', 'sd.g1', 'med.var.g1',


### PR DESCRIPTION
Users of `tidyverse` packages may be familiar with manipulating tibbles rather than base R's data frames. For example, R returns a tibble when a dataset is read using `readr::read_csv` rather than base R's `read.csv`. While tibbles *are* data frames (in that they possess the class `data.frame`), they do not work as inputs in the `metamedian` package's meta-analysis functions, namely `metamean`, `metamedian`, and `describe_studies`. This may confuse some users of the package.

```
> dat_age <- metamedian::dat.age
> mod1 <- metamedian::metamedian(data = dat_age)
> 
> dat_age <- tibble::as_tibble(metamedian::dat.age)
> mod2 <- metamedian::metamedian(data = dat_age)
Error in check_and_clean_df(df = data, method = median_method) : 
  Summary data must be of class numeric or integer. Column q1.g1 is not of one of these classes
In addition: Warning messages:
1: In if (!class(df[, col]) %in% c("numeric", "integer")) { :
  the condition has length > 1 and only the first element will be used
2: In if (class(df[, col]) %in% "logical" | all(is.na(df[, col]))) { :
  the condition has length > 1 and only the first element will be used
3: In if (!class(df[, col]) %in% c("numeric", "integer")) { :
  the condition has length > 1 and only the first element will be used
4: In if (class(df[, col]) %in% "logical" | all(is.na(df[, col]))) { :
  the condition has length > 1 and only the first element will be used
```

As seen in the code above, the function `check_and_clean_df` throws an error when the example dataset is converted to a tibble. This has to do with how the checks in the function are implemented and the differences in defaults between tibbles and base R's data frames. With `[` syntax, tibbles uses `drop=FALSE` as the default and pure data frames use `drop=TRUE`; the consequence of this is that when a single column is selected with `[` syntax, a base R data frame will be converted to an atomic vector (e.g., with class "logical", "numeric", etc.), whereas a tibble will remain a single-column data frame (with classes "tbl_df", "tbl", and "data.frame"). It will then fail the check and throw an error, as seen above.

The easiest way to fix this is to simply add a check for tibbles (check for the class "tbl_df") in `check_and_clean_df` and silently convert them to a pure data frame using `as.data.frame`. The alternative would be rewriting the checks in `check_and_clean_df` (and other parts of the code requiring this pattern, if there are any). I have opted for the former in this pull request.

Re-running the code above:

```
> dat_age <- metamedian::dat.age
> mod1 <- metamedian::metamedian(data = dat_age)
> 
> dat_age <- tibble::as_tibble(metamedian::dat.age)
> mod2 <- metamedian::metamedian(data = dat_age)
> 
> identical(mod1$fit.stats, mod2$fit.stats)
[1] TRUE
```

As always, thank you for your hard work on this great package!